### PR TITLE
Fix json-server command to work with the latest version

### DIFF
--- a/nodejs/docker-compose.yml
+++ b/nodejs/docker-compose.yml
@@ -2,7 +2,7 @@ version: '3.0'
 services:
   json-server:
     image: vimagick/json-server
-    command: -H 0.0.0.0 -p 8080 -w /config/db.json
+    command: -h 0.0.0.0 -p 8080 -w /config/db.json
     ports:
       - "8080:8080"
     volumes:


### PR DESCRIPTION
### Descripción del cambio

Se aplica un fix al comando del package json-server que se usa para levantar la mocked API. Se le estaba seteando el host mediante el flag `-H` pero el comando, en su ultima versión al menos, pide que ese flag se setee usando `-h`

### Before

![image](https://github.com/TiendaNube/tech-challenge/assets/13352933/0cf9f0a8-f925-4e2c-a8ed-03131bdb9044)


### After

![image](https://github.com/TiendaNube/tech-challenge/assets/13352933/1357afb1-823b-41a5-8b29-18e231d57b3b)
